### PR TITLE
ISSUE-117 Add list datasets by processing level to podaac_utils

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,10 +11,17 @@
 # governing permissions and limitations under the License.
 language: python
 python:
-  - '2.7'
-  - '3.3'
-  - '3.4'
-  - '3.5'
+  - "2.6"
+  - "2.7"
+  - "3.3"
+  - "3.4"
+  - "3.5"
+  - "3.5-dev"  # 3.5 development branch
+  - "3.6"
+  - "3.6-dev"  # 3.6 development branch
+  # PyPy versions
+  - "pypy2.7"
+  - "pypy3.5"
 notifications:
   email: false
 cache:

--- a/README.rst
+++ b/README.rst
@@ -6,7 +6,7 @@ podaacpy
 |image7|
 
 A python utility library for interacting with NASA JPL's
-`PO.DAAC <http://podaac.jpl.nasa.gov>`__
+`PO.DAAC <https://podaac.jpl.nasa.gov>`__
 
 What is PO.DAAC?
 ----------------
@@ -22,36 +22,36 @@ What does podaacpy offer?
 -------------------------
 
 The library provides a Python toolkit for interacting with all
-[PO.DAAC Web Services v3.2.2 APIs](http://podaac.jpl.nasa.gov/ws), namely
+[PO.DAAC Web Services v3.2.2 APIs](https://podaac.jpl.nasa.gov/ws), namely
 
 -  `PO.DAAC Web Services <https://podaac.jpl.nasa.gov/ws/>`__: services
    include
 -  `Dataset
-   Metadata <http://podaac.jpl.nasa.gov/ws/search/dataset/index.html>`__
+   Metadata <https://podaac.jpl.nasa.gov/ws/search/dataset/index.html>`__
    - retrieves the metadata of a dataset
 -  `Granule
-   Metadata <http://podaac.jpl.nasa.gov/ws/metadata/granule/index.html>`__
+   Metadata <https://podaac.jpl.nasa.gov/ws/metadata/granule/index.html>`__
    - retrieves the metadata of a granule
 -  `Search
-   Dataset <http://podaac.jpl.nasa.gov/ws/search/dataset/index.html>`__
+   Dataset <https://podaac.jpl.nasa.gov/ws/search/dataset/index.html>`__
    - searches PO.DAAC's dataset catalog, over Level 2, Level 3, and
    Level 4 datasets
 -  `Search
-   Granule <http://podaac.jpl.nasa.gov/ws/search/granule/index.html>`__
+   Granule <https://podaac.jpl.nasa.gov/ws/search/granule/index.html>`__
    - does granule searching on PO.DAAC level 2 swath datasets
    (individual orbits of a satellite), and level 3 & 4 gridded datasets
    (time averaged to span the globe)
 -  `Image
-   Granule <http://podaac.jpl.nasa.gov/ws/image/granule/index.html>`__ -
+   Granule <https://podaac.jpl.nasa.gov/ws/image/granule/index.html>`__ -
    renders granules in the PO.DAAC's catalog to images such as jpeg
    and/or png
 -  `Extract
-   Granule <http://podaac.jpl.nasa.gov/ws/extract/granule/index.html>`__
+   Granule <https://podaac.jpl.nasa.gov/ws/extract/granule/index.html>`__
    - subsets a granule in PO.DAAC catalog and produces either netcdf3 or
    hdf4 files
 
 -  | `Metadata Compliance
-     Checker <http://podaac-uat.jpl.nasa.gov/mcc>`__: an online tool and
+     Checker <https://podaac-uat.jpl.nasa.gov/mcc>`__: an online tool and
      web
    | service designed to check and validate the contents of netCDF and
      HDF granules for the

--- a/docs/source/introduction.rst
+++ b/docs/source/introduction.rst
@@ -42,7 +42,7 @@ The library provides a Python toolkit for interacting with all of PO.DAACs API's
  * `Granule Subset <https://podaac.jpl.nasa.gov/ws/subset/granule/index.html>`_ - Subset Granule service allows users to submit subset jobs
  * `Subset Status <https://podaac.jpl.nasa.gov/ws/subset/status/index.html>`_ - Subset Granule Status service allows users to check the status of submitted subset job
 
-* `Metadata Compliance Checker <http://podaac-uat.jpl.nasa.gov/mcc>`_: an online tool and web service designed to check and validate the contents of netCDF and HDF granules for the Climate and Forecast (CF) and Attribute Convention for Dataset Discovery (ACDD) metadata conventions.
+* `Metadata Compliance Checker <https://podaac-uat.jpl.nasa.gov/mcc>`_: an online tool and web service designed to check and validate the contents of netCDF and HDF granules for the Climate and Forecast (CF) and Attribute Convention for Dataset Discovery (ACDD) metadata conventions.
 
 Additionally, Podaacpy provides the following ocean-related data services 
 * `NASA OceanColor Web <https://oceancolor.gsfc.nasa.gov>`_:

--- a/docs/source/introduction.rst
+++ b/docs/source/introduction.rst
@@ -19,7 +19,7 @@ Introduction to podaacpy
 ============
 Introduction
 ============
-podaacpy is a python utility library for interacting with `NASA JPL's PO.DAAC <http://podaac.jpl.nasa.gov>`_
+podaacpy is a python utility library for interacting with `NASA JPL's PO.DAAC <https://podaac.jpl.nasa.gov>`_
 
 ================
 What is PO.DAAC?
@@ -33,14 +33,14 @@ The library provides a Python toolkit for interacting with all of PO.DAACs API's
 
 * `PO.DAAC Web Services <https://podaac.jpl.nasa.gov/ws/>`_: services include
 
- * `Dataset Metadata <http://podaac.jpl.nasa.gov/ws/metadata/dataset/index.html>`_ - retrieves the metadata of a dataset
- * `Dataset Search <http://podaac.jpl.nasa.gov/ws/search/dataset/index.html>`_ - searches PO.DAAC's dataset catalog, over Level 2, Level 3, and Level 4 datasets
- * `Dataset Variables <http://podaac.jpl.nasa.gov/ws/dataset/variables/index.html>`_ - provides list of dataset variables for the dataset
- * `Granule Metadata <http://podaac.jpl.nasa.gov/ws/metadata/granule/index.html>`_ - retrieves the metadata of a granule
- * `Granule Search <http://podaac.jpl.nasa.gov/ws/search/granule/index.html>`_ - does granule searching on PO.DAAC level 2 swath datasets (individual orbits of a satellite), and level 3 & 4 gridded datasets (time averaged to span the globe)
- * `Granule Preview <http://podaac.jpl.nasa.gov/ws/image/granule/index.html>`_ - the PODAAC preview Image service retrieves pre-generated preview images for selected granules
- * `Granule Subset <http://podaac.jpl.nasa.gov/ws/subset/granule/index.html>`_ - Subset Granule service allows users to submit subset jobs
- * `Subset Status <http://podaac.jpl.nasa.gov/ws/subset/status/index.html>`_ - Subset Granule Status service allows users to check the status of submitted subset job
+ * `Dataset Metadata <https://podaac.jpl.nasa.gov/ws/metadata/dataset/index.html>`_ - retrieves the metadata of a dataset
+ * `Dataset Search <https://podaac.jpl.nasa.gov/ws/search/dataset/index.html>`_ - searches PO.DAAC's dataset catalog, over Level 2, Level 3, and Level 4 datasets
+ * `Dataset Variables <https://podaac.jpl.nasa.gov/ws/dataset/variables/index.html>`_ - provides list of dataset variables for the dataset
+ * `Granule Metadata <https://podaac.jpl.nasa.gov/ws/metadata/granule/index.html>`_ - retrieves the metadata of a granule
+ * `Granule Search <https://podaac.jpl.nasa.gov/ws/search/granule/index.html>`_ - does granule searching on PO.DAAC level 2 swath datasets (individual orbits of a satellite), and level 3 & 4 gridded datasets (time averaged to span the globe)
+ * `Granule Preview <https://podaac.jpl.nasa.gov/ws/image/granule/index.html>`_ - the PODAAC preview Image service retrieves pre-generated preview images for selected granules
+ * `Granule Subset <https://podaac.jpl.nasa.gov/ws/subset/granule/index.html>`_ - Subset Granule service allows users to submit subset jobs
+ * `Subset Status <https://podaac.jpl.nasa.gov/ws/subset/status/index.html>`_ - Subset Granule Status service allows users to check the status of submitted subset job
 
 * `Metadata Compliance Checker <http://podaac-uat.jpl.nasa.gov/mcc>`_: an online tool and web service designed to check and validate the contents of netCDF and HDF granules for the Climate and Forecast (CF) and Attribute Convention for Dataset Discovery (ACDD) metadata conventions.
 

--- a/docs/source/quickstart.rst
+++ b/docs/source/quickstart.rst
@@ -68,7 +68,7 @@ For more information on these functions, see :doc:`utilities`
 
 Retrieving Dataset Metadata
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-`Dataset Metadata <http://podaac.jpl.nasa.gov/ws/search/dataset/index.html>`_ - retrieves the metadata of a dataset. In the following code snippet lets retrieve dataset metadata for GHRSST Level 2P Atlantic Regional Skin Sea Surface Temperature from the Spinning Enhanced Visible and InfraRed Imager (SEVIRI) on the Meteosat Second Generation (MSG-2) satellite e.g. dataset id **PODAAC-GHMG2-2PO01** ::
+`Dataset Metadata <https://podaac.jpl.nasa.gov/ws/search/dataset/index.html>`_ - retrieves the metadata of a dataset. In the following code snippet lets retrieve dataset metadata for GHRSST Level 2P Atlantic Regional Skin Sea Surface Temperature from the Spinning Enhanced Visible and InfraRed Imager (SEVIRI) on the Meteosat Second Generation (MSG-2) satellite e.g. dataset id **PODAAC-GHMG2-2PO01** ::
 
   result = p.dataset_metadata(dataset_id='PODAAC-GHMG2-2PO01')
 
@@ -77,7 +77,7 @@ For more information on this function, see :doc:`webservices`
 
 Retrieving Granule Metadata
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-`Granule Metadata <http://podaac.jpl.nasa.gov/ws/metadata/granule/index.html>`_ - retrieves the metadata of a granule. In the following code snippet we retrieve granule metadata for the above dataset e.g. granule_name **20120912-MSG02-OSDPD-L2P-MSG02_0200Z-v01.nc** ::
+`Granule Metadata <https://podaac.jpl.nasa.gov/ws/metadata/granule/index.html>`_ - retrieves the metadata of a granule. In the following code snippet we retrieve granule metadata for the above dataset e.g. granule_name **20120912-MSG02-OSDPD-L2P-MSG02_0200Z-v01.nc** ::
 
   result = p.granule_metadata(dataset_id='PODAAC-GHMG2-2PO01', granule_name='20120912-MSG02-OSDPD-L2P-MSG02_0200Z-v01.nc')
 
@@ -93,7 +93,7 @@ For more information on this function, see :doc:`webservices`
 
 Retrieving Dataset Variables
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-`Dataset Variables <http://podaac.jpl.nasa.gov/ws/dataset/variables/index.html>`_ - provides a list of variable for the datset. In the following code snippet we retrieve the dataset variables for the dataset id **PODAAC-ASOP2-25X01** ::
+`Dataset Variables <https://podaac.jpl.nasa.gov/ws/dataset/variables/index.html>`_ - provides a list of variable for the datset. In the following code snippet we retrieve the dataset variables for the dataset id **PODAAC-ASOP2-25X01** ::
 
   result = p..dataset_variables(dataset_id='PODAAC-ASOP2-25X01')
 
@@ -102,7 +102,7 @@ For more information on this function, see :doc:`webservices`
 
 Searching for Datasets
 ^^^^^^^^^^^^^^^^^^^^^^
-`Search Dataset <http://podaac.jpl.nasa.gov/ws/search/dataset/index.html>`_ - searches PO.DAAC's dataset catalog, over Level 2, Level 3, and Level 4 datasets. In the following code snippet we will search using a keyword e.g. **modis** ::
+`Search Dataset <https://podaac.jpl.nasa.gov/ws/search/dataset/index.html>`_ - searches PO.DAAC's dataset catalog, over Level 2, Level 3, and Level 4 datasets. In the following code snippet we will search using a keyword e.g. **modis** ::
 
    result = p.dataset_search(keyword='modis')
 
@@ -111,7 +111,7 @@ For more information on this function, see :doc:`webservices`
 
 Searching for Granules
 ^^^^^^^^^^^^^^^^^^^^^^^
-`Search Granule <http://podaac.jpl.nasa.gov/ws/search/granule/index.html>`_ - does granule searching on PO.DAAC level 2 swath datasets (individual orbits of a satellite), and level 3 & 4 gridded datasets (time averaged to span the globe). In the following code snippet we will search for granules within a specific dataset e.g. **PODAAC-ASOP2-25X01** ::
+`Search Granule <https://podaac.jpl.nasa.gov/ws/search/granule/index.html>`_ - does granule searching on PO.DAAC level 2 swath datasets (individual orbits of a satellite), and level 3 & 4 gridded datasets (time averaged to span the globe). In the following code snippet we will search for granules within a specific dataset e.g. **PODAAC-ASOP2-25X01** ::
 
    result = p.granule_search(dataset_id='PODAAC-ASOP2-25X01', bbox='0,0,180,90',start_time='2013-01-01T01:30:00Z',end_time='2014-01-01T00:00:00Z',start_index='1'))
 
@@ -120,7 +120,7 @@ For more information on this function, see :doc:`webservices`
 
 Retrieve granule images
 ^^^^^^^^^^^^^^^^^^^^^^^
-`Granule Preview <http://podaac.jpl.nasa.gov/ws/image/granule/index.html>`_ - renders granules in the PO.DAAC's catalog to images such as jpeg and/or png. In the following code snippet we display a request using the dataset id **PODAAC-ASOP2-25X01** and image variable of the dataset **wind_speed** ::
+`Granule Preview <https://podaac.jpl.nasa.gov/ws/image/granule/index.html>`_ - renders granules in the PO.DAAC's catalog to images such as jpeg and/or png. In the following code snippet we display a request using the dataset id **PODAAC-ASOP2-25X01** and image variable of the dataset **wind_speed** ::
 
    result = p.granule_preview(dataset_id='PODAAC-ASOP2-25X01', image_variable='wind_speed')
 
@@ -132,7 +132,7 @@ For more information on this function, see :doc:`webservices`
 
 Subsetting Granules
 ^^^^^^^^^^^^^^^^^^^
-`Granule Subset <http://podaac.jpl.nasa.gov/ws/subset/granule/index.html>`_ - the Granule Subset web service sets up a granule subsetting job using HTTP POST request. Upon a successful request, a token is returned which can be used to check the status of the subsetting job. In the following code snippet we will subset a granule using an input.json file which contains ::
+`Granule Subset <https://podaac.jpl.nasa.gov/ws/subset/granule/index.html>`_ - the Granule Subset web service sets up a granule subsetting job using HTTP POST request. Upon a successful request, a token is returned which can be used to check the status of the subsetting job. In the following code snippet we will subset a granule using an input.json file which contains ::
 
    query={ 
     "email":"abc@abcd.com",
@@ -154,7 +154,7 @@ For more information on this function, see :doc:`webservices`
 
 Subset Status
 ^^^^^^^^^^^^^
-`Subset Status <http://podaac.jpl.nasa.gov/ws/subset/status/index.html>`_ - the subset status checks the status on the existing job. In the following code snippet we check the status using the token received from PO.DAAC when we submitted a job for subsetting ::
+`Subset Status <https://podaac.jpl.nasa.gov/ws/subset/status/index.html>`_ - the subset status checks the status on the existing job. In the following code snippet we check the status using the token received from PO.DAAC when we submitted a job for subsetting ::
 
    result = p.granule_preview(dataset_id='PODAAC-ASOP2-25X01', image_variable='wind_speed')
 
@@ -163,7 +163,7 @@ For more information on this function, see :doc:`webservices`
 
 Extract level4 granule
 ^^^^^^^^^^^^^^^^^^^^^^
-Right now the `Extract Granule <http://podaac.jpl.nasa.gov/ws/extract/granule/index.html>` supports only level 2 granules. Extract l4 granule is an add-on over extract granule to extract level 4 gridded datasets from the PODAAC data source. In the following code snippet we extract a level4 granule with Dataset ID = **PODAAC-CCF30-01XXX**, short_name of **CCMP_MEASURES_ATLAS_L4_OW_L3_0_WIND_VECTORS_FLK** and provide a path to the directory you want to have it saved as **netcdf** ::
+Right now the `Extract Granule <https://podaac.jpl.nasa.gov/ws/extract/granule/index.html>` supports only level 2 granules. Extract l4 granule is an add-on over extract granule to extract level 4 gridded datasets from the PODAAC data source. In the following code snippet we extract a level4 granule with Dataset ID = **PODAAC-CCF30-01XXX**, short_name of **CCMP_MEASURES_ATLAS_L4_OW_L3_0_WIND_VECTORS_FLK** and provide a path to the directory you want to have it saved as **netcdf** ::
 
    result = p.extract_l4_granule(dataset_id='PODAAC-CCF30-01XXX', short_name='CCMP_MEASURES_ATLAS_L4_OW_L3_0_WIND_VECTORS_FLK', path='path/to/the/destination/directory')
 

--- a/podaac/mcc.py
+++ b/podaac/mcc.py
@@ -23,7 +23,7 @@ class MCC:
 
     def check_remote_file(self, checkers, url_upload, response='json'):
         '''GET a remote file e.g. from an OPeNDAP URL and compliance \
-                check it against the endpoint at http://podaac-uat.jpl.nasa.gov/mcc/check.
+                check it against the endpoint at https://podaac-uat.jpl.nasa.gov/mcc/check.
 
         :param checkers: Must specify at least one test. Multiple tests are \
                 delimited by commas. Possible values include 'ACDD-x.x', \
@@ -59,7 +59,7 @@ class MCC:
 
     def check_local_file(self, acdd_version, gds2_parameters, file_upload, response='json'):
         '''POST a local file to the metadata compliance checker \
-                endpoint at http://podaac-uat.jpl.nasa.gov/mcc/check
+                endpoint at https://podaac-uat.jpl.nasa.gov/mcc/check
 
         :param acdd_version: Must be present and and set to either 1.1 or 1.3. \
                 'acdd' tag must also be present and must be set to 'on'.

--- a/podaac/podaac.py
+++ b/podaac/podaac.py
@@ -19,7 +19,6 @@ import gzip
 import json
 import ntpath
 import os
-from podaac import podaac_utils
 import requests
 import time
 import xml.etree.ElementTree as ET

--- a/podaac/podaac.py
+++ b/podaac/podaac.py
@@ -12,17 +12,18 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import requests
 from future.moves.urllib.parse import urlencode
 from future.moves.urllib.request import urlopen, urlretrieve
 from future.moves.http.client import HTTPSConnection
 import gzip
-import os
-import zipfile
 import json
+import ntpath
+import os
+from podaac import podaac_utils
+import requests
 import time
 import xml.etree.ElementTree as ET
-import ntpath
+import zipfile
 
 URL = 'https://podaac.jpl.nasa.gov/ws/'
 IMAGE_URL = 'https://podaac-tools.jpl.nasa.gov/l2ss-services/l2ss/preview/'

--- a/podaac/podaac_utils.py
+++ b/podaac/podaac_utils.py
@@ -13,9 +13,7 @@
 # limitations under the License.
 
 from bs4 import BeautifulSoup
-import sys
-sys.path.insert(0, '../podaac')
-from podaac import podaac as pd
+from . import podaac as pd
 import requests
 import xml.etree.ElementTree as ET
 

--- a/podaac/podaac_utils.py
+++ b/podaac/podaac_utils.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 from bs4 import BeautifulSoup
+sys.path.insert(0, '../podaac')
 from podaac import podaac as pd
 import requests
 import xml.etree.ElementTree as ET

--- a/podaac/podaac_utils.py
+++ b/podaac/podaac_utils.py
@@ -12,8 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import requests
 from bs4 import BeautifulSoup
+from podaac import podaac as pd
+import requests
 import xml.etree.ElementTree as ET
 
 
@@ -22,106 +23,9 @@ class PodaacUtils:
     def __init__(self):
         self.URL = 'https://podaac.jpl.nasa.gov/ws/'
 
-    def list_available_granule_search_level2_dataset_ids(self):
+    def list_all_available_extract_granule_dataset_ids(self):
         '''Convenience function which returns an up-to-date \
-                list of available level2 granule dataset id's.
-
-        :returns: a comma-seperated list of granule dataset id's
-
-        '''
-        dataset_ids = []
-        url = 'http://podaac.jpl.nasa.gov/l2ssIngest/datasets'
-        response = requests.get(url)
-        data = response.json()
-
-        for item in data["datasets"]:
-            dataset_ids.append(item["persistentId"])
-
-        return dataset_ids
-
-    def list_available_granule_search_level2_dataset_short_names(self):
-        '''Convenience function which returns an up-to-date \
-                list of available level2 granule dataset short names.
-
-        :returns: a comma-seperated list of granule dataset short names.
-
-        '''
-        dataset_ids = []
-        url = 'http://podaac.jpl.nasa.gov/l2ssIngest/datasets'
-        response = requests.get(url)
-        data = response.json()
-
-        for item in data["datasets"]:
-            dataset_ids.append(item["shortName"])
-
-        return dataset_ids
-
-    def list_available_granule_search_dataset_ids(self):
-        '''Convenience function which returns an up-to-date \
-                list of available granule dataset id's.
-
-        :returns: a comma-seperated list of granule dataset id's
-
-        '''
-        data_part1 = requests.get(
-            self.URL + 'search/dataset/?format=atom&itemsPerPage=400').text
-        data_part2 = requests.get(
-            self.URL + 'search/dataset?startIndex=400&itemsPerPage=400&format=atom').text
-        root1 = ET.fromstring(data_part1.encode('utf-8'))
-        root2 = ET.fromstring(data_part2.encode('utf-8'))
-
-        dataset_ids = []
-        for entry in root1.findall('{http://www.w3.org/2005/Atom}entry'):
-            dataset_id = entry.find(
-                '{http://podaac.jpl.nasa.gov/opensearch/}datasetId').text
-            dataset_ids.append(dataset_id)
-
-        for entry in root2.findall('{http://www.w3.org/2005/Atom}entry'):
-            dataset_id = entry.find(
-                '{http://podaac.jpl.nasa.gov/opensearch/}datasetId').text
-            dataset_ids.append(dataset_id)
-
-        dataset_ids_level1 = []
-        dataset_ids_level2 = self.list_available_granule_search_level2_dataset_ids()
-        dataset_ids_level1 = list(set(dataset_ids) - set(dataset_ids_level2))
-
-        return dataset_ids_level1
-
-    def list_available_granule_search_dataset_short_names(self):
-        '''Convenience function which returns an up-to-date \
-                list of available granule dataset short names.
-
-        :returns: a comma-seperated list of granule dataset short names.
-
-        '''
-        data_part1 = requests.get(
-            self.URL + 'search/dataset/?format=atom&itemsPerPage=400').text
-        data_part2 = requests.get(
-            self.URL + 'search/dataset?startIndex=400&itemsPerPage=400&format=atom').text
-        root1 = ET.fromstring(data_part1.encode('utf-8'))
-        root2 = ET.fromstring(data_part2.encode('utf-8'))
-
-        dataset_short_names = []
-        for entry in root1.findall('{http://www.w3.org/2005/Atom}entry'):
-            name = entry.find(
-                '{http://podaac.jpl.nasa.gov/opensearch/}shortName').text
-            dataset_short_names.append(name)
-
-        for entry in root2.findall('{http://www.w3.org/2005/Atom}entry'):
-            name = entry.find(
-                '{http://podaac.jpl.nasa.gov/opensearch/}shortName').text
-            dataset_short_names.append(name)
-
-        # dataset_short_names_level1 = []
-        dataset_short_names_level2 = self.list_available_granule_search_level2_dataset_short_names()
-        dataset_short_names_level1 = list(
-            set(dataset_short_names) - set(dataset_short_names_level2))
-
-        return dataset_short_names_level1
-
-    def list_available_extract_granule_dataset_ids(self):
-        '''Convenience function which returns an up-to-date \
-                list of available granule dataset id's which can be \
+                list of all available granule dataset id's which can be \
                 used in the granule extraction service.
 
         :returns: a comma-seperated list of granule dataset id's.
@@ -141,9 +45,9 @@ class PodaacUtils:
 
         return dataset_ids
 
-    def list_available_extract_granule_dataset_short_names(self):
+    def list_all_available_extract_granule_dataset_short_names(self):
         '''Convenience function which returns an up-to-date \
-                list of available granule dataset short names which can be \
+                list of all available granule dataset short names which can be \
                 used in the granule extraction service.
 
         :returns: a comma-seperated list of granule dataset short names.
@@ -162,3 +66,138 @@ class PodaacUtils:
             dataset_short_names.append(x[1].text.encode('utf-8'))
 
         return dataset_short_names
+
+    def list_all_available_granule_search_dataset_ids(self):
+        '''Convenience function which returns an up-to-date \
+                list of available all granule dataset id's.
+
+        :returns: a comma-seperated list of granule dataset id's
+
+        '''
+        data_part1 = requests.get(
+            self.URL + 'search/dataset/?format=atom&itemsPerPage=400').text
+        data_part2 = requests.get(
+            self.URL + 'search/dataset?startIndex=400&itemsPerPage=400&format=atom').text
+        root1 = ET.fromstring(data_part1.encode('utf-8'))
+        root2 = ET.fromstring(data_part2.encode('utf-8'))
+
+        dataset_ids = []
+        for entry in root1.findall('{http://www.w3.org/2005/Atom}entry'):
+            dataset_id = entry.find(
+                '{https://podaac.jpl.nasa.gov/opensearch/}datasetId').text
+            dataset_ids.append(dataset_id)
+
+        for entry in root2.findall('{http://www.w3.org/2005/Atom}entry'):
+            dataset_id = entry.find(
+                '{https://podaac.jpl.nasa.gov/opensearch/}datasetId').text
+            dataset_ids.append(dataset_id)
+
+        dataset_ids_level1 = []
+        dataset_ids_level2 = self.list_available_granule_search_level2_dataset_ids()
+        dataset_ids_level1 = list(set(dataset_ids) - set(dataset_ids_level2))
+
+        return dataset_ids_level1
+
+    def list_all_available_granule_search_dataset_short_names(self):
+        '''Convenience function which returns an up-to-date \
+                list of available granule dataset short names.
+
+        :returns: a comma-seperated list of granule dataset short names.
+
+        '''
+        data_part1 = requests.get(
+            self.URL + 'search/dataset/?format=atom&itemsPerPage=400').text
+        data_part2 = requests.get(
+            self.URL + 'search/dataset?startIndex=400&itemsPerPage=400&format=atom').text
+        root1 = ET.fromstring(data_part1.encode('utf-8'))
+        root2 = ET.fromstring(data_part2.encode('utf-8'))
+
+        dataset_short_names = []
+        for entry in root1.findall('{http://www.w3.org/2005/Atom}entry'):
+            name = entry.find(
+                '{https://podaac.jpl.nasa.gov/opensearch/}shortName').text
+            dataset_short_names.append(name)
+
+        for entry in root2.findall('{http://www.w3.org/2005/Atom}entry'):
+            name = entry.find(
+                '{https://podaac.jpl.nasa.gov/opensearch/}shortName').text
+            dataset_short_names.append(name)
+
+        # dataset_short_names_level1 = []
+        dataset_short_names_level2 = self.list_available_granule_search_level2_dataset_short_names()
+        dataset_short_names_level1 = list(
+            set(dataset_short_names) - set(dataset_short_names_level2))
+
+        return dataset_short_names_level1
+
+    def list_available_granule_search_level2_dataset_ids(self):
+        '''Convenience function which returns an up-to-date \
+                list of available level2 granule dataset id's.
+
+        :returns: a comma-seperated list of granule dataset id's
+
+        '''
+        dataset_ids = []
+        url = 'https://podaac.jpl.nasa.gov/l2ssIngest/datasets'
+        response = requests.get(url)
+        data = response.json()
+
+        for item in data["datasets"]:
+            dataset_ids.append(item["persistentId"])
+
+        return dataset_ids
+
+    def list_available_granule_search_level2_dataset_short_names(self):
+        '''Convenience function which returns an up-to-date \
+                list of available level2 granule dataset short names.
+
+        :returns: a comma-seperated list of granule dataset short names.
+
+        '''
+        dataset_ids = []
+        url = 'https://podaac.jpl.nasa.gov/l2ssIngest/datasets'
+        response = requests.get(url)
+        data = response.json()
+
+        for item in data["datasets"]:
+            dataset_ids.append(item["shortName"])
+
+        return dataset_ids
+
+    def list_level4_dataset_ids(self):
+        '''Convenience function which returns an up-to-date \
+                list of level4 dataset id's.
+
+        :returns: a comma-seperated list of level4 dataset id's
+
+        '''
+        podaac = pd.Podaac()
+        data = podaac.dataset_search(process_level='4', items_per_page='400')
+        root = ET.fromstring(data.encode('utf-8'))
+
+        dataset_ids = []
+        for entry in root.findall('{http://www.w3.org/2005/Atom}entry'):
+            dataset_id = entry.find(
+                '{https://podaac.jpl.nasa.gov/opensearch/}datasetId').text
+            dataset_ids.append(dataset_id)
+
+        return dataset_ids
+
+    def list_level4_dataset_short_names(self):
+        '''Convenience function which returns an up-to-date \
+                list of level4 dataset short names.
+
+        :returns: a comma-seperated list of level4 dataset short names.
+
+        '''
+        podaac = pd.Podaac()
+        data = podaac.dataset_search(process_level='4', items_per_page='400')
+        l4_dataset_short_names = []
+        root = ET.fromstring(data.encode('utf-8'))
+
+        for entry in root.findall('{http://www.w3.org/2005/Atom}entry'):
+            l4_dataset_short_name = entry.find(
+                '{https://podaac.jpl.nasa.gov/opensearch/}shortName').text
+            l4_dataset_short_names.append(l4_dataset_short_name)
+
+        return l4_dataset_short_names

--- a/podaac/podaac_utils.py
+++ b/podaac/podaac_utils.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 from bs4 import BeautifulSoup
+import sys
 sys.path.insert(0, '../podaac')
 from podaac import podaac as pd
 import requests

--- a/podaac/tests/podaac_test.py
+++ b/podaac/tests/podaac_test.py
@@ -126,7 +126,7 @@ class TestPodaac(unittest.TestCase):
             dataset_id=test_dataset_id, start_time=start_time, end_time=end_time, bbox=bbox, start_index=start_index, format=format)
         root = ET.fromstring(granules.encode('utf-8'))
         dataset_id = root.find('{http://www.w3.org/2005/Atom}entry').find(
-            '{http://podaac.jpl.nasa.gov/opensearch/}datasetId').text.rsplit('.')[0]
+            '{https://podaac.jpl.nasa.gov/opensearch/}datasetId').text.rsplit('.')[0]
 
         assert granules != None
         assert test_dataset_id == dataset_id

--- a/podaac/tests/podaac_test.py
+++ b/podaac/tests/podaac_test.py
@@ -29,10 +29,10 @@ class TestPodaac(unittest.TestCase):
         self.podaac = Podaac()
         self.podaac_utils = PodaacUtils()
 
-    # test case for the function load_dataset_md()
+    # test case for the function dataset_metadata()
     def test_dataset_metadata(self):
-        dataset_id = 'PODAAC-GHMG2-2PO01'
-        dataset_short_name = 'OSDPD-L2P-MSG02'
+        dataset_id = 'PODAAC-CCF35-01AD5'
+        dataset_short_name = 'CCMP_MEASURES_ATLAS_L4_OW_L3_5A_5DAY_WIND_VECTORS_FLK'
         dataset_md = self.podaac.dataset_metadata(
             dataset_id, dataset_short_name)
         root = ET.fromstring(dataset_md.encode('utf-8'))
@@ -41,15 +41,15 @@ class TestPodaac(unittest.TestCase):
         assert dataset_md != None
         assert str(short_name['id']) == dataset_short_name
         assert_raises(requests.exceptions.HTTPError, self.podaac.dataset_metadata,
-                      'PODAAC-GHMG2-2PO01', 'OSDPD-L2P-MSG02', 'is')
+                      'PODAAC-CCF35-01AD5', 'CCMP_MEASURES_ATLAS_L4_OW_L3_5A_5DAY_WIND_VECTORS_FLK', 'is')
         assert_raises(Exception, self.podaac.dataset_metadata,
-                      short_name='OSDPD-L2P-MSG02')
+                      short_name='CCMP_MEASURES_ATLAS_L4_OW_L3_5A_5DAY_WIND_VECTORS_FLK')
 
-    # test case for the fucntion load_granule_md()
+    # test case for the fucntion granule_metadata()
     def test_granule_metadata(self):
-        dataset_id = 'PODAAC-GHMG2-2PO01'
-        dataset_short_name = 'OSDPD-L2P-MSG02'
-        granule_name = '20120912-MSG02-OSDPD-L2P-MSG02_0200Z-v01.nc'
+        dataset_id = 'PODAAC-GHK10-41N01'
+        dataset_short_name = 'NAVO-L4HR1m-GLOB-K10_SST'
+        granule_name = '20180312-NAVO-L4HR1m-GLOB-v01-fv01_0-K10_SST.nc'
 
         granule_md = self.podaac.granule_metadata(
             dataset_id=dataset_id, short_name=dataset_short_name, granule_name=granule_name)
@@ -190,18 +190,18 @@ class TestPodaac(unittest.TestCase):
         path = os.path.join(os.path.dirname(__file__), granule_name)
         os.remove(path)
 
-    # test case for the function list_available_granule_search_dataset_ids()
+    # test case for the function list_all_available_granule_search_dataset_ids()
     def test_list_available_granule_search_dataset_ids(self):
-        data = self.podaac_utils.list_available_granule_search_dataset_ids()
+        data = self.podaac_utils.list_all_available_granule_search_dataset_ids()
 
         assert data != None
         assert type(data) is list
         assert len(data) != 0
 
     # test case for the function
-    # list_available_granule_search_dataset_short_names()
+    # list_all_available_granule_search_dataset_short_names()
     def test_list_available_granule_search_dataset_short_names(self):
-        data = self.podaac_utils.list_available_granule_search_dataset_short_names()
+        data = self.podaac_utils.list_all_available_granule_search_dataset_short_names()
 
         assert data != None
         assert type(data) is list
@@ -225,18 +225,36 @@ class TestPodaac(unittest.TestCase):
         assert type(data) is list
         assert len(data) != 0
 
-    # test case for the function list_available_extract_granule_dataset_ids()
+    # test case for the function list_all_available_extract_granule_dataset_ids()
     def test_list_available_extract_granule_dataset_ids(self):
-        data = self.podaac_utils.list_available_extract_granule_dataset_ids()
+        data = self.podaac_utils.list_all_available_extract_granule_dataset_ids()
 
         assert data != None
         assert type(data) is list
         assert len(data) != 0
 
     # test case for the function
-    # list_available_extract_granule_dataset_short_names()
+    # list_all_available_extract_granule_dataset_short_names()
     def test_list_available_extract_granule_dataset_short_names(self):
-        data = self.podaac_utils.list_available_extract_granule_dataset_short_names()
+        data = self.podaac_utils.list_all_available_extract_granule_dataset_short_names()
+
+        assert data != None
+        assert type(data) is list
+        assert len(data) != 0
+
+    # test case for the function
+    # list_level4_dataset_ids()
+    def test_list_level4_dataset_ids(self):
+        data = self.podaac_utils.list_level4_dataset_ids()
+
+        assert data != None
+        assert type(data) is list
+        assert len(data) != 0
+
+    # test case for the function
+    # list_level4_dataset_short_names()
+    def test_list_level4_dataset_short_names(self):
+        data = self.podaac_utils.list_level4_dataset_short_names()
 
         assert data != None
         assert type(data) is list


### PR DESCRIPTION
This PR 

- rearranges the functions in ```podaac/podaac_utils.py``` such that they are in alphabetical order
- adds two new functions, namely ```list_level4_dataset_ids``` and ```list_level4_dataset_short_names``` which aid in using OCW for Level4-specific applications such as Apache OCW.