### PR TITLE
Corrected method names in the getting started notebook

### DIFF
--- a/examples/podaacpy_getting_started_tutorial.ipynb
+++ b/examples/podaacpy_getting_started_tutorial.ipynb
@@ -38,7 +38,7 @@
     "###########################################\n",
     "# Lets look at some convenience functions #\n",
     "###########################################\n",
-    "print(u.list_available_extract_granule_dataset_ids())"
+    "print(u.list_all_available_extract_granule_dataset_ids())"
    ]
   },
   {
@@ -47,7 +47,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "print(u.list_available_extract_granule_dataset_short_names())"
+    "print(u.list_all_available_extract_granule_dataset_short_names())"
    ]
   },
   {
@@ -56,7 +56,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "print(u.list_available_granule_search_dataset_ids())"
+    "print(u.list_all_available_granule_search_dataset_ids())"
    ]
   },
   {
@@ -65,7 +65,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "print(u.list_available_granule_search_dataset_short_names())"
+    "print(u.list_all_available_granule_search_dataset_short_names())"
    ]
   },
   {


### PR DESCRIPTION
The convenience functions were failing because the method names had been updated in commit 38a8672
which addressed ISSUE-117 (Add list datasets by processing level to podaac_utils) but changed the name of these methods.